### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ executable:
       user => 'foo',
     }
 
+Handle Dependecy Order
+-----------------
+
+Handle the PHP dependency with Custom Stages. Make composer wait for PHP. 
+
+    class { 'composer':
+      command_name => 'composer',
+      target_dir   => '/usr/local/bin', 
+      auto_update => true, 
+      stage => last,
+    }
+    stage { 'last': }
+    Stage['main'] -> Stage['last']
+
+Custom Stages Reference: http://docs.puppetlabs.com/puppet/3/reference/lang_run_stages.html
 
 Running the tests
 -----------------


### PR DESCRIPTION
Fix a PHP dependency issue causing the following error during provisioning. 

==> default: err: /Stage[main]/Composer/Exec[composer-update]/returns: change from notrun to 0 failed: /usr/bin/env: php: No such file or directory

Cause: composer being installed before PHP. 
Solution: Add Custom Stages to make composer install at last, after PHP.